### PR TITLE
Add support for deployment to Cloudflare Pages

### DIFF
--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --project-name=${{vars.CLOUDFLARE_PAGES_PROJECT_NAME}}
+          command: pages deploy ${{github.workspace}}/${{env.listPublishDirectory}} --project-name=${{vars.CLOUDFLARE_PAGES_PROJECT_NAME}}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Pages

--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ${{github.workspace}}/${{env.listPublishDirectory}} --project-name=${{vars.CLOUDFLARE_PAGES_PROJECT_NAME}}
+          command: pages deploy ${{env.listPublishDirectory}} --project-name=${{vars.CLOUDFLARE_PAGES_PROJECT_NAME}}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Pages

--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --project-name={{ vars.CLOUDFLARE_PAGES_PROJECT_NAME }}
+          command: pages deploy $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --project-name=${{vars.CLOUDFLARE_PAGES_PROJECT_NAME}}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Pages

--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -51,9 +51,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
@@ -68,6 +65,10 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --project-name={{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Pages
+        if: env.CLOUDFLARE_PAGES_PROJECT_NAME == ''
+        uses: actions/configure-pages@v5
           
       - name: Deploy to GitHub Pages
         if: env.CLOUDFLARE_PAGES_PROJECT_NAME == ''

--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -58,7 +58,18 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ${{env.listPublishDirectory}}
+
+      - name: Deploy To Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        id: deployment-cloudflare
+        if: env.CLOUDFLARE_PAGES_PROJECT_NAME != ''
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --project-name={{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Deploy to GitHub Pages
-        id: deployment
+        if: env.CLOUDFLARE_PAGES_PROJECT_NAME == ''
+        id: deployment-github
         uses: actions/deploy-pages@v4

--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -59,18 +59,18 @@ jobs:
       - name: Deploy To Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         id: deployment-cloudflare
-        if: env.CLOUDFLARE_PAGES_PROJECT_NAME != ''
+        if: vars.CLOUDFLARE_PAGES_PROJECT_NAME != ''
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --project-name={{ env.CLOUDFLARE_PAGES_PROJECT_NAME }}
+          command: pages deploy $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --project-name={{ vars.CLOUDFLARE_PAGES_PROJECT_NAME }}
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Pages
-        if: env.CLOUDFLARE_PAGES_PROJECT_NAME == ''
+        if: vars.CLOUDFLARE_PAGES_PROJECT_NAME == ''
         uses: actions/configure-pages@v5
           
       - name: Deploy to GitHub Pages
-        if: env.CLOUDFLARE_PAGES_PROJECT_NAME == ''
+        if: vars.CLOUDFLARE_PAGES_PROJECT_NAME == ''
         id: deployment-github
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Whenever you make a change to the `main` branch, or when you trigger it manually
 
 The contents of the `Website` directory can be customized to change the appearance of the landing page. Most of the information will be automatically filled in with information from [`source.json`](source.json). Customizing the landing page by hand is not required.
 
+## Using Cloudflare Pages (Optional)
+
+If you want to use Cloudflare Pages instead of Github Pages, please follow these steps:
+
+1. Follow [Cloudflare Docs](https://developers.cloudflare.com/pages/how-to/use-direct-upload-with-continuous-integration/#deploy-with-wrangler) to configure your `id` and `token` in the `Repository secrets`
+2. Trun to `Repository variables` and add a new variable named `CLOUDFLARE_PAGES_PROJECT_NAME` with value to be your pages project name
+3. Trigger the workflow to run and observe your Cloudflare Dashboard.
+
+Note that the Cloudflare Pages deployment is prior to Github Pages deployment (i.e. we will not deploy to Github Pages once configured `CLOUDFLARE_PAGES_PROJECT_NAME`).
+
 ## Technical Stuff
 
 You are welcome to make your own changes to the automation process to make it fit your needs, and you can create Pull Requests if you have some changes you think we should adopt. Here's some more info on the included automation:


### PR DESCRIPTION
Some users like me would like to deploy the site on cloudflare pages for more flexible configuration.

This PR will add support it.  These users should follow the additive steps (listed in readme) to configure secrets and variables in the repo.

Please note that the PR has multiple commit and should be squashed to merge.

Thanks.

