### PR TITLE
Pin @fluentui/web-components CDN imports to v2.6.1

### DIFF
--- a/Website/app.js
+++ b/Website/app.js
@@ -1,4 +1,4 @@
-import { baseLayerLuminance, StandardLuminance } from 'https://unpkg.com/@fluentui/web-components';
+import { baseLayerLuminance, StandardLuminance } from 'https://unpkg.com/@fluentui/web-components@2.6.1';
 
 const LISTING_URL = "{{ listingInfo.Url }}";
 

--- a/Website/index.html
+++ b/Website/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>VCC Listing</title>
-  <script type="module" src="https://unpkg.com/@fluentui/web-components"></script>
+  <script type="module" src="https://unpkg.com/@fluentui/web-components@2.6.1"></script>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- `index.html` and `app.js` load `@fluentui/web-components` from unpkg without a version pin, so they always resolve to the latest release.
- The package recently published `3.0.0`, a full rewrite that removes `StandardLuminance`/`baseLayerLuminance` (used in `app.js` for theme switching) and drops components this template relies on entirely, including `fluent-data-grid` and `fluent-text-field` (renamed to `fluent-text-input` in v3).
- This breaks every site generated from this template with `Uncaught SyntaxError: The requested module 'https://unpkg.com/@fluentui/web-components' does not provide an export named 'StandardLuminance'`.
- Pinning both CDN imports to `2.6.1` (the last v2 release) restores the working API and component set, and prevents future silent breakage from upstream major version bumps.